### PR TITLE
ci: Add Python 3.11 to GitHub Actions

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python: ["3.10"]
+        python: ["3.10", "3.11"]
         nox_session: ["_example", "docs", "pre-commit", "testing"]
         exclude:
           - os: macos-latest

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,7 @@ import nox
 from nox_poetry import Session, session
 
 # Define the Python versions under test
-PYTHON_VERSIONS = ["3.10"]
+PYTHON_VERSIONS = ["3.10", "3.11"]
 
 # Set minimum required version of `nox`
 nox.needs_version = ">=2023.4.22"

--- a/{{ cookiecutter.repository_name }}/.github/workflows/nox.yml
+++ b/{{ cookiecutter.repository_name }}/.github/workflows/nox.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python: ["3.10"]
+        python: ["3.10", "3.11"]
         nox_session: ["docs", "pre-commit", "testing"]
         exclude:
           - os: macos-latest

--- a/{{ cookiecutter.repository_name }}/noxfile.py
+++ b/{{ cookiecutter.repository_name }}/noxfile.py
@@ -6,7 +6,7 @@ import nox
 from nox_poetry import Session, session
 
 # Define the Python versions under test
-PYTHON_VERSIONS = ["3.10"]
+PYTHON_VERSIONS = ["3.10", "3.11"]
 
 # Set minimum required version of `nox`
 nox.needs_version = ">=2023.4.22"


### PR DESCRIPTION
# Summary

PR #27 bumped the repository to Python 3.10, but we should probably support checks for up to Python 3.11 at least (current status is for security fixes only).

## Checklists

I/we (contributor) confirm that the code, and analyses in this Pull Request (developments) meets the following requirements:

- [x] code runs
- [x] developments are ethical, and secure
- [x] contributor has made proportionate checks that the developments are correct
- [x] minimum usable documentation is written in plain English in the `docs` folder
- [x] all pre-commit hooks pass
- [x] test suite passes
- [x] code coverage is maintained, or increased

## Additional comments

N/A