### PR TITLE
feat: Add project commit SHA to `THIRD_PARTY_NOTICES`

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,7 +5,8 @@
   ],
   "_extensions": [
     "cookiecutter.extensions.SlugifyExtension",
-    "cookiecutter.extensions.TimeExtension"
+    "cookiecutter.extensions.TimeExtension",
+    "jinja2_git.GitExtension"
   ],
 
   "author": "Name",

--- a/poetry.lock
+++ b/poetry.lock
@@ -808,6 +808,20 @@ MarkupSafe = ">=2.0"
 i18n = ["Babel (>=2.7)"]
 
 [[package]]
+name = "jinja2-git"
+version = "1.3.0"
+description = "Jinja2 extension to handle git-specific things"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "jinja2-git-1.3.0.tar.gz", hash = "sha256:20b15497548cf86eefb116b11141e30ed2a690e0ea5d71f0e5cd17ccdf77491a"},
+    {file = "jinja2_git-1.3.0-py3-none-any.whl", hash = "sha256:b12d160e898b0afd6a9903c3d67c5c8fb7383674b34d79f3604681e95bd4f536"},
+]
+
+[package.dependencies]
+jinja2 = ">=2.10,<4.0"
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
@@ -2141,4 +2155,4 @@ requests = "*"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "bcee914e890690fd31d9577f72ed79256c983ea89c233e500084dbcffd8c3b7b"
+content-hash = "94f17da171607e7e9aeeb08108752a805839015cd840533decabe35ca4c6bf88"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ exclude = []
 python = ">=3.10,<3.13"
 cookiecutter = "^2.5.0"
 cruft = {extras = ["pyproject"], version = "^2.15.0"}
+jinja2-git = "^1.3.0"
 
 [tool.poetry.group.ci-cd]
 optional = true

--- a/{{ cookiecutter.repository_name }}/THIRD_PARTY_NOTICES
+++ b/{{ cookiecutter.repository_name }}/THIRD_PARTY_NOTICES
@@ -3,7 +3,7 @@ THIRD PARTY NOTICES
 This repository includes material listed below, or described in the code.
 
 ----------------------------------------------------------------------------------------
-@ESKYoung/cookiecutter-machine-learning 2.x.x
+@ESKYoung/cookiecutter-machine-learning at commit `{% gitcommit short=True %}`
 https://github.com/ESKYoung/cookiecutter-machine-learning
 
     MIT License


### PR DESCRIPTION
# Summary

For clarity, the `THIRD_PARTY_NOTICES` for this repository licence should include the version or commit SHA any downstream repository branched off from. For ease, it's better to use the commit SHA since `main` (in future) may not necessarily be a release.

## Checklists

I/we (contributor) confirm that the code, and analyses in this Pull Request (developments) meets the following requirements:

- [x] code runs
- [x] developments are ethical, and secure
- [x] contributor has made proportionate checks that the developments are correct
- [x] minimum usable documentation is written in plain English in the `docs` folder
- [x] all pre-commit hooks pass
- [x] test suite passes
- [x] code coverage is maintained, or increased

## Additional comments

N/A