### PR TITLE
test: Ignore `tests` directory from coverage checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,9 +75,6 @@ build-backend = "poetry.core.masonry.api"
 config = "./pyproject.toml"
 force-exclude = "^/\\{\\{ cookiecutter\\.repository_name \\}\\}/pyproject\\.toml$"
 
-[tool.coverage.run]
-omit = ["{{ cookiecutter.repository_name }}/*"]
-
 [tool.coverage.paths]
 source = ["hooks", "src"]
 
@@ -85,9 +82,11 @@ source = ["hooks", "src"]
 exclude_lines = ["if __name__ == .__main__.:"]
 fail_under = 90
 show_missing = true
-
 [tool.isort]
 profile = "black"
+
+[tool.coverage.run]
+omit = ["{{ cookiecutter.repository_name }}/*", "tests/*"]
 
 [tool.mypy]
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,8 +80,8 @@ source = ["hooks", "src"]
 
 [tool.coverage.report]
 exclude_lines = ["if __name__ == .__main__.:"]
-fail_under = 90
 show_missing = true
+
 [tool.isort]
 profile = "black"
 

--- a/{{ cookiecutter.repository_name }}/pyproject.toml
+++ b/{{ cookiecutter.repository_name }}/pyproject.toml
@@ -96,6 +96,9 @@ exclude_lines = ["if __name__ == .__main__.:"]
 fail_under = 90
 show_missing = true
 
+[tool.coverage.run]
+omit = ["tests/*"]
+
 [tool.isort]
 profile = "black"
 

--- a/{{ cookiecutter.repository_name }}/pyproject.toml
+++ b/{{ cookiecutter.repository_name }}/pyproject.toml
@@ -93,7 +93,6 @@ source = ["src"]
 
 [tool.coverage.report]
 exclude_lines = ["if __name__ == .__main__.:"]
-fail_under = 90
 show_missing = true
 
 [tool.coverage.run]


### PR DESCRIPTION
# Summary

Currently, coverage reports extend to the `tests` directory, which is unreasonable. Omitting from now on.

## Checklists

I/we (contributor) confirm that the code, and analyses in this Pull Request (developments) meets the following requirements:

- [x] code runs
- [x] developments are ethical, and secure
- [x] contributor has made proportionate checks that the developments are correct
- [x] minimum usable documentation is written in plain English in the `docs` folder
- [x] all pre-commit hooks pass
- [x] test suite passes
- [x] code coverage is maintained, or increased

## Additional comments

N/A