### PR TITLE
docs: Update `README.md` to clarify that hooks may fail on first commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,19 @@ git add .
 git commit
 ```
 
+> On your first commit, some pre-commit hooks may fail due to formatting issues caused
+> by your answers to the `cruft create` prompts. This is expected, so fix the issues as
+> normal if it occurs (see `CONTRIBUTING.md`).
+
 Finally, [create an empty GitHub repository without any optional
 files][github-create-repo], or [create a blank project on GitLab without any optional
-files][gitlab-create-repo] and follow the instructions to push your first commit. Note
-that CI/CD workflows are built with GitHub Actions; GitLab CI/CD is not currently
+files][gitlab-create-repo] and follow the instructions to push your first commit.
+
+Note that CI/CD workflows are built with GitHub Actions; GitLab CI/CD is not currently
 supported.
+
+Note, pre-commit hooks may fail on your first commit due to formatting; fix these according to
+the `CONTRIBUTING.md` before proceeding.
 
 ### Requirements
 


### PR DESCRIPTION
# Summary

Pre-commit hooks may fail on the first commit due to the Jinja templating. For example, a long package name may cause some lines of code to exceed the desired width, causing `black` to reformat the code. Adding this to the documentation so that users are aware.

## Checklists

I/we (contributor) confirm that the code, and analyses in this Pull Request (developments) meets the following requirements:

- [x] code runs
- [x] developments are ethical, and secure
- [x] contributor has made proportionate checks that the developments are correct
- [x] minimum usable documentation is written in plain English in the `docs` folder
- [x] all pre-commit hooks pass
- [x] test suite passes
- [x] code coverage is maintained, or increased

## Additional comments

<!--
Add additional comments here, if relevant. For example, provide comments for any items
not checked off in the checklist above, suggest a review strategy, or flag any gotchas
for the reviewer.
-- >
