### PR TITLE
fix: Fix `jinja2-git` dependency

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,8 +5,7 @@
   ],
   "_extensions": [
     "cookiecutter.extensions.SlugifyExtension",
-    "cookiecutter.extensions.TimeExtension",
-    "jinja2_git.GitExtension"
+    "cookiecutter.extensions.TimeExtension"
   ],
 
   "author": "Name",

--- a/poetry.lock
+++ b/poetry.lock
@@ -808,20 +808,6 @@ MarkupSafe = ">=2.0"
 i18n = ["Babel (>=2.7)"]
 
 [[package]]
-name = "jinja2-git"
-version = "1.3.0"
-description = "Jinja2 extension to handle git-specific things"
-optional = false
-python-versions = ">=3.7,<4.0"
-files = [
-    {file = "jinja2-git-1.3.0.tar.gz", hash = "sha256:20b15497548cf86eefb116b11141e30ed2a690e0ea5d71f0e5cd17ccdf77491a"},
-    {file = "jinja2_git-1.3.0-py3-none-any.whl", hash = "sha256:b12d160e898b0afd6a9903c3d67c5c8fb7383674b34d79f3604681e95bd4f536"},
-]
-
-[package.dependencies]
-jinja2 = ">=2.10,<4.0"
-
-[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
@@ -2139,4 +2125,4 @@ requests = "*"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "88926fc61440cd5c070105046d716fc93a17cdf4a4ca788e41f7f5bef954e899"
+content-hash = "0f3b62bb7b60243608452246123de54973c7f35c1e319ddfe6eea053bdec8f65"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ exclude = []
 python = ">=3.10,<3.13"
 cookiecutter = "^2.5.0"
 cruft = {extras = ["pyproject"], version = "^2.15.0"}
-jinja2-git = "^1.3.0"
 
 [tool.poetry.group.ci-cd]
 optional = true

--- a/{{ cookiecutter.repository_name }}/THIRD_PARTY_NOTICES
+++ b/{{ cookiecutter.repository_name }}/THIRD_PARTY_NOTICES
@@ -3,7 +3,7 @@ THIRD PARTY NOTICES
 This repository includes material listed below, or described in the code.
 
 ----------------------------------------------------------------------------------------
-@ESKYoung/cookiecutter-machine-learning at commit `{% gitcommit short=True %}`
+@ESKYoung/cookiecutter-machine-learning (see `.cruft.json` for commit SHA)
 https://github.com/ESKYoung/cookiecutter-machine-learning
 
     MIT License


### PR DESCRIPTION
# Summary

This required users to have `jinja2-git` installed before `cruft create` could work; it's not ideal to have this so have removed this in favour of a more low-key solution.

## Checklists

I/we (contributor) confirm that the code, and analyses in this Pull Request (developments) meets the following requirements:

- [x] code runs
- [x] developments are ethical, and secure
- [x] contributor has made proportionate checks that the developments are correct
- [x] minimum usable documentation is written in plain English in the `docs` folder
- [x] all pre-commit hooks pass
- [x] test suite passes
- [x] code coverage is maintained, or increased

## Additional comments

N/A