### PR TITLE
docs: add missing `hooks` API documentation

### DIFF
--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -10,7 +10,9 @@ This page gives an overview of all public objects, functions, and methods in the
 .. autosummary::
     :toctree: api/
 
+    disable_cruft_autoupdater_github_action
     git_init
+    main
     run_commands_if_exist
 
 ```

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -42,7 +42,7 @@ def run_commands_if_exist(command_args: Sequence[Sequence[str]]) -> None:
 
 
 def disable_cruft_autoupdater_github_action(template_link: Optional[str]) -> None:
-    """Disable the `cruft` autoupdater GitHub Action if not using public HTTPS links."""
+    """Disable the ``cruft`` autoupdater GitHub Action if not using public HTTPS links."""
     if template_link is None or not template_link.startswith("https://www.github.com/"):
         github_action_path = Path(".github", "workflows", "cruft-autoupdate.yml")
         github_action_path.rename(github_action_path.with_suffix(".yml.disabled"))


### PR DESCRIPTION
# Summary

The `hooks` API reference is missing documentation. This should add it in.

## Checklists

I/we (contributor) confirm that the code, and analyses in this Pull Request (developments) meets the following requirements:

- [x] code runs
- [x] developments are ethical, and secure
- [x] contributor has made proportionate checks that the developments are correct
- [x] minimum usable documentation is written in plain English in the `docs` folder
- [x] all pre-commit hooks pass
- [x] test suite passes
- [x] code coverage is maintained, or increased

## Additional comments

N/A